### PR TITLE
Introduce Opt-in mode as an alternative configuration

### DIFF
--- a/lib/keycloak-api-rails.rb
+++ b/lib/keycloak-api-rails.rb
@@ -4,6 +4,7 @@ require "uri"
 require "date"
 require "net/http"
 
+require_relative "keycloak-api-rails/authentication"
 require_relative "keycloak-api-rails/configuration"
 require_relative "keycloak-api-rails/http_client"
 require_relative "keycloak-api-rails/token_error"
@@ -46,6 +47,7 @@ module Keycloak
       config.realm_id                               = nil
       config.logger                                 = ::Logger.new(STDOUT)
       config.skip_paths                             = {}
+      config.opt_in                                 = false
       config.token_expiration_tolerance_in_seconds  = 10
       config.public_key_cache_ttl                   = 86400
       config.custom_attributes                      = []

--- a/lib/keycloak-api-rails/authentication.rb
+++ b/lib/keycloak-api-rails/authentication.rb
@@ -1,24 +1,27 @@
 module Keycloak
+  module Authentication
+    extend ActiveSupport::Concern
 
-  class Middleware
-    def initialize(app)
-      @app = app
+    included do
+      if respond_to?(:helper_method)
+        helper_method :keycloak_authenticate
+      end
     end
 
-    def call(env)
+    protected
+
+    def keycloak_authenticate
+      
+      env = request.env
       method = env["REQUEST_METHOD"]
       path   = env["PATH_INFO"]
       uri    = env["REQUEST_URI"]
 
-      if service.need_middleware_authentication?(method, path, env)
-        logger.debug("Start authentication for #{method} : #{path}")
-        token         = service.read_token(uri, env)
-        decoded_token = service.decode_and_verify(token)
-        authentication_succeeded(env, decoded_token)
-      else
-        logger.debug("Skip authentication for #{method} : #{path}")
-        @app.call(env)
-      end
+      logger.debug("Start authentication for #{method} : #{path}")
+      token         = service.read_token(uri, env)
+      decoded_token = service.decode_and_verify(token)
+      authentication_succeeded(env, decoded_token)
+      
     rescue TokenError => e
       authentication_failed(e.message)
     end
@@ -37,7 +40,6 @@ module Keycloak
       Helper.assign_realm_roles(env, decoded_token)
       Helper.assign_resource_roles(env, decoded_token)
       Helper.assign_keycloak_token(env, decoded_token)
-      @app.call(env)
     end
 
     def service

--- a/lib/keycloak-api-rails/configuration.rb
+++ b/lib/keycloak-api-rails/configuration.rb
@@ -4,6 +4,7 @@ module Keycloak
     config_accessor :server_url
     config_accessor :realm_id
     config_accessor :skip_paths
+    config_accessor :opt_in
     config_accessor :token_expiration_tolerance_in_seconds
     config_accessor :public_key_cache_ttl
     config_accessor :custom_attributes

--- a/lib/keycloak-api-rails/service.rb
+++ b/lib/keycloak-api-rails/service.rb
@@ -4,6 +4,7 @@ module Keycloak
     def initialize(key_resolver)
       @key_resolver                          = key_resolver
       @skip_paths                            = Keycloak.config.skip_paths
+      @opt_in                                = Keycloak.config.opt_in
       @logger                                = Keycloak.config.logger
       @token_expiration_tolerance_in_seconds = Keycloak.config.token_expiration_tolerance_in_seconds
     end
@@ -34,8 +35,8 @@ module Keycloak
       Helper.read_token_from_query_string(uri) || Helper.read_token_from_headers(headers)
     end
 
-    def need_authentication?(method, path, headers)
-      !should_skip?(method, path) && !is_preflight?(method, headers)
+    def need_middleware_authentication?(method, path, headers)
+      !is_preflight?(method, headers) && (!@opt_in && !should_skip?(method, path))
     end
 
     private

--- a/lib/keycloak-api-rails/version.rb
+++ b/lib/keycloak-api-rails/version.rb
@@ -1,3 +1,3 @@
 module Keycloak
-  VERSION = "0.11.1"
+  VERSION = "0.12.0"
 end

--- a/spec/keycloak-api-rails/authentication_spec.rb
+++ b/spec/keycloak-api-rails/authentication_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe Keycloak::Authentication do
+  class ExampleController < ActionController::Base
+    include Keycloak::Authentication
+    # Mark protected methods public so they may be called in tests
+    public(*Keycloak::Authentication.protected_instance_methods)
+  end
+
+  let(:controller) { ExampleController.new }
+  let(:token) { 'keycloak_valid_token'}
+  let(:headers) do
+    {
+      'REQUEST_METHOD' => :get,
+      'REQUEST_URI' => 'http://www.an-url.io',
+      'HTTP_AUTHORIZATION' => "Bearer #{token}"
+    }
+  end
+
+  describe "#keycloak_authenticate" do
+    before do
+      # Mock request object because we aren't using real request spec
+      allow(controller).to receive(:request).and_return(double("request", env: headers ))
+    end
+
+    it "it authenticates with request header" do
+      expect_any_instance_of(Keycloak::Service).to receive(:decode_and_verify).with(token).and_return("A User")
+      expect(controller).to receive(:authentication_succeeded)
+      controller.keycloak_authenticate
+    end
+  end
+end

--- a/spec/keycloak-api-rails/service_spec.rb
+++ b/spec/keycloak-api-rails/service_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Keycloak::Service do
     end
   end
 
-  describe "#need_authentication?" do
+  describe "#need_middleware_authentication?" do
 
     let(:method)  { nil }
     let(:path)    { nil }
@@ -115,7 +115,7 @@ RSpec.describe Keycloak::Service do
         post:   [/^\/skip/],
         get:    [/^\/skip/]
       }
-      @result = service.need_authentication?(method, path, headers)
+      @result = service.need_middleware_authentication?(method, path, headers)
     end
 
     context "when method is nil" do
@@ -171,6 +171,18 @@ RSpec.describe Keycloak::Service do
       let(:method)  { :options }
       let(:headers) { { "HTTP_ACCESS_CONTROL_REQUEST_METHOD" => ["Authorization"] } }
       let(:path)    { "/do-not-skip" }
+      it "should return false" do
+        expect(@result).to be false
+      end
+    end
+
+    context "when configured as opt_in" do
+      before do
+        Keycloak.config.opt_in = true
+        service2 = Keycloak::Service.new(key_resolver)
+        @result = service2.need_middleware_authentication?(method, path, headers)
+      end
+
       it "should return false" do
         expect(@result).to be false
       end


### PR DESCRIPTION
Introduces a new configuration option, and a new mode of operating as a request filter. 

**Tl;DR:** 
If keycloak-api-rails is configured with `opt_in: true`, it will not validate all requests by default. Instead, it will allow controllers to opt-in to validation. 

**Use Case**
As our API expands, we have several clients/systems interacting with that API, and several different rules/modes of authentication. We see an increase in the number of controllers/routes that require a mode of authentication other than Keycloak (e.g. some use static API tokens, some use a different OAuth provider). We have a few issues that we've encountered:
 - The skip_paths list is growing, and it's challenging to maintain a list of many regexp. We find we have to write tests to validate the list of regexp meets our expectations
 - It's difficult to get granular control of validation. E.g we need to patch the middleware, which can be brittle.
 - Application errors are hidden by authentication errors. E.g. When we try to CURL a path that doesn't exist in our app, we get a 401 response instead of a 404

**Solution**
Keycloak-api-rails will continue to use the same middleware implementation unchanged, by default.

However, if it is configured with `opt-in: true`, that middleware will not be used, and instead Keycloak can be called explicitly. In other words, controllers/routes will **opt-in** to validation, rather than having to opt-out with a skip_path setting

Example Config:
```ruby
Keycloak.configure do |config|
  config.server_url = ENV["KEYCLOAK_SERVER_URL"]
  config.realm_id   = ENV["KEYCLOAK_REALM_ID"]
  config.logger     = Rails.logger
  config.opt_in     = true
end
```

When opt-in mode is used, Keycloak will not validate requests in the middleware layer. Application will need to authenticate with Keycloak by including the authentication module, and calling the helper (e.g. from a controller)

```ruby
class AuthenticatedController < ApplicationController
  include Keycloak::Authentication

  before_action :keycloak_authenticate, only: show

  def show
    # requires Keycloak authentication
    keycloak_id = Keycloak::Helper.current_user_id(request.env)
    User.active.find_by(keycloak_id: keycloak_id)
  end

  def index 
    # unauthenticated
  end
end
```

Nothing changes about the mechanism for validating the token itself. 

