### PR TITLE
Fixes for opt-in mode

### DIFF
--- a/lib/keycloak-api-rails/authentication.rb
+++ b/lib/keycloak-api-rails/authentication.rb
@@ -28,7 +28,7 @@ module Keycloak
 
     def authentication_failed(message)
       logger.info(message)
-      render status: :unauthorized, json: { error: "Invalid Token" }
+      render status: :unauthorized, json: { error: message }
     end
 
     def authentication_succeeded(env, decoded_token)

--- a/lib/keycloak-api-rails/authentication.rb
+++ b/lib/keycloak-api-rails/authentication.rb
@@ -28,7 +28,7 @@ module Keycloak
 
     def authentication_failed(message)
       logger.info(message)
-      [401, {"Content-Type" => "application/json"}, [ { error: message }.to_json]]
+      render status: :unauthorized, json: { error: "Invalid Token" }
     end
 
     def authentication_succeeded(env, decoded_token)

--- a/lib/keycloak-api-rails/helper.rb
+++ b/lib/keycloak-api-rails/helper.rb
@@ -83,11 +83,14 @@ module Keycloak
     end
 
     def self.read_token_from_query_string(uri)
-      return "" unless uri.present?
-      parsed_uri         = URI.parse(uri)
-      query              = URI.decode_www_form(parsed_uri.query || "")
-      query_string_token = query.detect { |param| param.first == QUERY_STRING_TOKEN_KEY }
-      query_string_token&.second
+      if uri.present?
+        parsed_uri         = URI.parse(uri)
+        query              = URI.decode_www_form(parsed_uri.query || "")
+        query_string_token = query.detect { |param| param.first == QUERY_STRING_TOKEN_KEY }
+        query_string_token&.second
+      else
+        ""
+      end
     end
 
     def self.create_url_with_token(uri, token)

--- a/lib/keycloak-api-rails/helper.rb
+++ b/lib/keycloak-api-rails/helper.rb
@@ -83,6 +83,7 @@ module Keycloak
     end
 
     def self.read_token_from_query_string(uri)
+      return "" unless uri.present?
       parsed_uri         = URI.parse(uri)
       query              = URI.decode_www_form(parsed_uri.query || "")
       query_string_token = query.detect { |param| param.first == QUERY_STRING_TOKEN_KEY }

--- a/lib/keycloak-api-rails/version.rb
+++ b/lib/keycloak-api-rails/version.rb
@@ -1,3 +1,3 @@
 module Keycloak
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/spec/keycloak-api-rails/service_spec.rb
+++ b/spec/keycloak-api-rails/service_spec.rb
@@ -235,6 +235,13 @@ RSpec.describe Keycloak::Service do
         end
       end
 
+      context "and query string is nil" do
+        let(:query_string) { nil }
+        it "returns an empty token" do
+          expect(@token).to eq ""
+        end
+      end
+
       context "but in the query string" do
         let(:query_string) { "&authorizationToken=#{query_string_token}" }
         it "returns the query string token" do


### PR DESCRIPTION
Follow-up to https://github.com/looorent/keycloak-api-rails/pull/47. This handles a minor edge case that will frequently happen when testing in a Rails app.

When using opt-in mode, Keycloak-api-rails (KAR) is now going to be called directly from controllers, including when controllers are called from tests (rspec, minitest, etc.) Generally these tests won't include the full rails request context. Specifically, in rspec controller specs, REQUEST_URI will be nil. This was throwing an error on URI.parse While we could modify the application to only authenticate in non-test runs, I think it makes sense for KAR to handle a nil URI

We didn't have to worry about this in middleware mode, because rspec simply doesn't include the middleware in tests.

Additionally, when called from a controller, the authentication module will need to render a 401 on auth failure, as opposed to returning a status code.