### PR TITLE
Fix opt in authentication overriding Rails config

### DIFF
--- a/lib/keycloak-api-rails/authentication.rb
+++ b/lib/keycloak-api-rails/authentication.rb
@@ -11,23 +11,21 @@ module Keycloak
     protected
 
     def keycloak_authenticate
-      
       env = request.env
       method = env["REQUEST_METHOD"]
       path   = env["PATH_INFO"]
       uri    = env["REQUEST_URI"]
 
-      logger.debug("Start authentication for #{method} : #{path}")
-      token         = service.read_token(uri, env)
-      decoded_token = service.decode_and_verify(token)
+      Keycloak.logger.debug("Start authentication for #{method} : #{path}")
+      token         = Keycloak.service.read_token(uri, env)
+      decoded_token = Keycloak.service.decode_and_verify(token)
       authentication_succeeded(env, decoded_token)
-      
     rescue TokenError => e
       authentication_failed(e.message)
     end
 
     def authentication_failed(message)
-      logger.info(message)
+      Keycloak.logger.info(message)
       render status: :unauthorized, json: { error: message }
     end
 
@@ -36,22 +34,10 @@ module Keycloak
       Helper.assign_current_authorized_party(env, decoded_token)
       Helper.assign_current_user_email(env, decoded_token)
       Helper.assign_current_user_locale(env, decoded_token)
-      Helper.assign_current_user_custom_attributes(env, decoded_token, config.custom_attributes)
+      Helper.assign_current_user_custom_attributes(env, decoded_token, Keycloak.config.custom_attributes)
       Helper.assign_realm_roles(env, decoded_token)
       Helper.assign_resource_roles(env, decoded_token)
       Helper.assign_keycloak_token(env, decoded_token)
-    end
-
-    def service
-      Keycloak.service
-    end
-
-    def logger
-      Keycloak.logger
-    end
-
-    def config
-      Keycloak.config
     end
   end
 end


### PR DESCRIPTION
When I configured Keyclock with `opt-in: true` and included `Keycloak::Authentication` in my controller all requests started failing with an error:
```
undefined method `allow_forgery_protection' for #<Keycloak::Configuration>
```
It looks like `Keyclock::Authentication` module overwrites native Rails `config` and `logger` methods with Keyclock's. I removed those methods and changed the `Authentication` module to use Keyclock methods directly.

