### PR TITLE
[Draft] Initial refactoring for dynamic config based on request

### DIFF
--- a/lib/keycloak-api-rails.rb
+++ b/lib/keycloak-api-rails.rb
@@ -16,41 +16,22 @@ require_relative "keycloak-api-rails/middleware"
 require_relative "keycloak-api-rails/railtie" if defined?(Rails)
 
 module Keycloak
-
-  def self.configure
-    yield @configuration ||= Keycloak::Configuration.new
-  end
-
-  def self.config
-    @configuration
-  end
-
-  def self.http_client
-    @http_client ||= Keycloak::HTTPClient.new(config)
-  end
-
-  def self.public_key_resolver
-    @public_key_resolver ||= PublicKeyCachedResolver.from_configuration(http_client, config)
-  end
-
-  def self.service
-    @service ||= Keycloak::Service.new(public_key_resolver)
-  end
-
-  def self.logger
-    config.logger
+  def self.configure(&block)
+    @configure_block = block
   end
 
   def self.load_configuration
-    configure do |config|
-      config.server_url                             = nil
-      config.realm_id                               = nil
-      config.logger                                 = ::Logger.new(STDOUT)
-      config.skip_paths                             = {}
-      config.opt_in                                 = false
-      config.token_expiration_tolerance_in_seconds  = 10
-      config.public_key_cache_ttl                   = 86400
-      config.custom_attributes                      = []
+    lambda do |_request|
+      configure do |config|
+        config.server_url                             = nil
+        config.realm_id                               = nil
+        config.logger                                 = ::Logger.new(STDOUT)
+        config.skip_paths                             = {}
+        config.opt_in                                 = false
+        config.token_expiration_tolerance_in_seconds  = 10
+        config.public_key_cache_ttl                   = 86400
+        config.custom_attributes                      = []
+      end
     end
   end
 

--- a/lib/keycloak-api-rails/authentication.rb
+++ b/lib/keycloak-api-rails/authentication.rb
@@ -12,20 +12,13 @@ module Keycloak
 
     def keycloak_authenticate
       env = request.env
-      method = env["REQUEST_METHOD"]
-      path   = env["PATH_INFO"]
-      uri    = env["REQUEST_URI"]
-
-      Keycloak.logger.debug("Start authentication for #{method} : #{path}")
-      token         = Keycloak.service.read_token(uri, env)
-      decoded_token = Keycloak.service.decode_and_verify(token)
-      authentication_succeeded(env, decoded_token)
+      service = ServiceFactory.from_env(env)
+      service.authenticate!(env)
     rescue TokenError => e
       authentication_failed(e.message)
     end
 
     def authentication_failed(message)
-      Keycloak.logger.info(message)
       render status: :unauthorized, json: { error: message }
     end
 

--- a/lib/keycloak-api-rails/configuration.rb
+++ b/lib/keycloak-api-rails/configuration.rb
@@ -1,14 +1,19 @@
 module Keycloak
-  class Configuration
-    include ActiveSupport::Configurable
-    config_accessor :server_url
-    config_accessor :realm_id
-    config_accessor :skip_paths
-    config_accessor :opt_in
-    config_accessor :token_expiration_tolerance_in_seconds
-    config_accessor :public_key_cache_ttl
-    config_accessor :custom_attributes
-    config_accessor :logger
-    config_accessor :ca_certificate_file
+  Configuration = Struct.new(
+    :server_url,
+    :realm_id,
+    :skip_paths,
+    :opt_in,
+    :token_expiration_tolerance_in_seconds,
+    :public_key_cache_ttl,
+    :custom_attributes,
+    :logger,
+    :ca_certificate_file,
+    keyword_init: true
+  ) do
+    def self.from(request)
+      config_block = Keycloak.configuration_block.call(request)
+      new.tap { |config| config_block.call(config) }
+    end
   end
 end

--- a/lib/keycloak-api-rails/middleware.rb
+++ b/lib/keycloak-api-rails/middleware.rb
@@ -1,55 +1,19 @@
 module Keycloak
-
   class Middleware
     def initialize(app)
       @app = app
     end
 
     def call(env)
-      method = env["REQUEST_METHOD"]
-      path   = env["PATH_INFO"]
-      uri    = env["REQUEST_URI"]
-
-      if service.need_middleware_authentication?(method, path, env)
-        logger.debug("Start authentication for #{method} : #{path}")
-        token         = service.read_token(uri, env)
-        decoded_token = service.decode_and_verify(token)
-        authentication_succeeded(env, decoded_token)
-      else
-        logger.debug("Skip authentication for #{method} : #{path}")
-        @app.call(env)
-      end
+      service = ServiceFactory.from_env(env)
+      service.authenticate!(env)
+      @app.call(env)
     rescue TokenError => e
       authentication_failed(e.message)
     end
 
     def authentication_failed(message)
-      logger.info(message)
       [401, {"Content-Type" => "application/json"}, [ { error: message }.to_json]]
-    end
-
-    def authentication_succeeded(env, decoded_token)
-      Helper.assign_current_user_id(env, decoded_token)
-      Helper.assign_current_authorized_party(env, decoded_token)
-      Helper.assign_current_user_email(env, decoded_token)
-      Helper.assign_current_user_locale(env, decoded_token)
-      Helper.assign_current_user_custom_attributes(env, decoded_token, config.custom_attributes)
-      Helper.assign_realm_roles(env, decoded_token)
-      Helper.assign_resource_roles(env, decoded_token)
-      Helper.assign_keycloak_token(env, decoded_token)
-      @app.call(env)
-    end
-
-    def service
-      Keycloak.service
-    end
-
-    def logger
-      Keycloak.logger
-    end
-
-    def config
-      Keycloak.config
     end
   end
 end

--- a/lib/keycloak-api-rails/service_factory.rb
+++ b/lib/keycloak-api-rails/service_factory.rb
@@ -1,0 +1,10 @@
+module Keycloak
+  class ServiceFactory
+    def from_env(env)
+      config = Keycloak::Configuration.from(ActionDispatch::Request.new(env))
+      http_client = Keycloak::HTTPClient.new(config)
+      key_resolver = Keycloak::PublicKeyCachedResolver.from_configuration(http_client, config)
+      service = Keycloak::Service.new(key_resolver)
+    end
+  end
+end


### PR DESCRIPTION
Hi Lorent,

I've made some untested changes to make the configuration dynamic and removed some duplicate code. The idea behind this pull request is to see if you would be willing to accept something like this.

We have been using this gem to authenticate our Rails APIs, but we use different Keycloak realms for different tenants. Therefore, we would like to configure the Keycloak endpoints based on the request.

For example, if the URL is `https://ourapp.com/hdfc`, then we will know that `hdfc` is the tenant, and we will configure the Keycloak endpoints accordingly.

Now, the configure block would look like this:

```ruby
Keycloak.configure do |request|
  lambda do |config|
    config.realm_id = request.url.split('/').last
    ...
  end
end
```

Please let me know your thoughts. I can add tests accordingly.