### PR TITLE
Change module name from Keycloak -> KeycloakApiRails 

### DIFF
--- a/keycloak-api-rails.gemspec
+++ b/keycloak-api-rails.gemspec
@@ -4,7 +4,7 @@ require "keycloak-api-rails/version"
 
 Gem::Specification.new do |spec|
   spec.name        = "keycloak-api-rails"
-  spec.version     = Keycloak::VERSION
+  spec.version     = KeycloakApiRails::VERSION
   spec.authors     = ["Lorent Lempereur"]
   spec.email       = ["lorent.lempereur.dev@gmail.com"]
   spec.homepage    = "https://github.com/looorent/keycloak-api-rails"

--- a/lib/keycloak-api-rails.rb
+++ b/lib/keycloak-api-rails.rb
@@ -15,10 +15,10 @@ require_relative "keycloak-api-rails/service"
 require_relative "keycloak-api-rails/middleware"
 require_relative "keycloak-api-rails/railtie" if defined?(Rails)
 
-module Keycloak
+module KeycloakApiRails
 
   def self.configure
-    yield @configuration ||= Keycloak::Configuration.new
+    yield @configuration ||= KeycloakApiRails::Configuration.new
   end
 
   def self.config
@@ -26,7 +26,7 @@ module Keycloak
   end
 
   def self.http_client
-    @http_client ||= Keycloak::HTTPClient.new(config, logger)
+    @http_client ||= KeycloakApiRails::HTTPClient.new(config, logger)
   end
 
   def self.public_key_resolver
@@ -34,7 +34,7 @@ module Keycloak
   end
 
   def self.service
-    @service ||= Keycloak::Service.new(public_key_resolver)
+    @service ||= KeycloakApiRails::Service.new(public_key_resolver)
   end
 
   def self.logger

--- a/lib/keycloak-api-rails/authentication.rb
+++ b/lib/keycloak-api-rails/authentication.rb
@@ -1,4 +1,4 @@
-module Keycloak
+module KeycloakApiRails
   module Authentication
     extend ActiveSupport::Concern
 
@@ -16,16 +16,16 @@ module Keycloak
       path   = env["PATH_INFO"]
       uri    = env["REQUEST_URI"]
 
-      Keycloak.logger.debug("Start authentication for #{method} : #{path}")
-      token         = Keycloak.service.read_token(uri, env)
-      decoded_token = Keycloak.service.decode_and_verify(token)
+      KeycloakApiRails.logger.debug("Start authentication for #{method} : #{path}")
+      token         = KeycloakApiRails.service.read_token(uri, env)
+      decoded_token = KeycloakApiRails.service.decode_and_verify(token)
       authentication_succeeded(env, decoded_token)
     rescue TokenError => e
       authentication_failed(e.message)
     end
 
     def authentication_failed(message)
-      Keycloak.logger.info(message)
+      KeycloakApiRails.logger.info(message)
       render status: :unauthorized, json: { error: message }
     end
 
@@ -34,7 +34,7 @@ module Keycloak
       Helper.assign_current_authorized_party(env, decoded_token)
       Helper.assign_current_user_email(env, decoded_token)
       Helper.assign_current_user_locale(env, decoded_token)
-      Helper.assign_current_user_custom_attributes(env, decoded_token, Keycloak.config.custom_attributes)
+      Helper.assign_current_user_custom_attributes(env, decoded_token, KeycloakApiRails.config.custom_attributes)
       Helper.assign_realm_roles(env, decoded_token)
       Helper.assign_resource_roles(env, decoded_token)
       Helper.assign_keycloak_token(env, decoded_token)

--- a/lib/keycloak-api-rails/configuration.rb
+++ b/lib/keycloak-api-rails/configuration.rb
@@ -1,4 +1,4 @@
-module Keycloak
+module KeycloakApiRails
   class Configuration
     include ActiveSupport::Configurable
     config_accessor :server_url

--- a/lib/keycloak-api-rails/helper.rb
+++ b/lib/keycloak-api-rails/helper.rb
@@ -1,4 +1,4 @@
-module Keycloak
+module KeycloakApiRails
   class Helper
 
     CURRENT_USER_ID_KEY          = "keycloak:keycloak_id"

--- a/lib/keycloak-api-rails/http_client.rb
+++ b/lib/keycloak-api-rails/http_client.rb
@@ -1,4 +1,4 @@
-module Keycloak
+module KeycloakApiRails
   class HTTPClient
     def initialize(configuration, logger)
       @server_url          = configuration.server_url
@@ -20,7 +20,7 @@ module Keycloak
           response.value
           JSON.parse(response.body)
         rescue
-          @logger.error("Keycloak responded with an error when calling '#{path}'. Status #{response.code}. Payload: #{response.body}")
+          @logger.error("KeycloakApiRails responded with an error when calling '#{path}'. Status #{response.code}. Payload: #{response.body}")
         end
       end
     end

--- a/lib/keycloak-api-rails/middleware.rb
+++ b/lib/keycloak-api-rails/middleware.rb
@@ -25,7 +25,7 @@ module KeycloakApiRails
     end
 
     def authentication_failed(message)
-      [401, {"Content-Type" => "application/json"}, [ { error: message }.to_json]]
+      [401, {"Content-Type" => "application/json"}, [ { error: I18n.t(message) }.to_json]]
     end
 
     def authentication_succeeded(env, decoded_token)

--- a/lib/keycloak-api-rails/middleware.rb
+++ b/lib/keycloak-api-rails/middleware.rb
@@ -1,4 +1,4 @@
-module Keycloak
+module KeycloakApiRails
 
   class Middleware
     def initialize(app)
@@ -41,15 +41,15 @@ module Keycloak
     end
 
     def service
-      Keycloak.service
+      KeycloakApiRails.service
     end
 
     def logger
-      Keycloak.logger
+      KeycloakApiRails.logger
     end
 
     def config
-      Keycloak.config
+      KeycloakApiRails.config
     end
   end
 end

--- a/lib/keycloak-api-rails/public_key_cached_resolver.rb
+++ b/lib/keycloak-api-rails/public_key_cached_resolver.rb
@@ -1,4 +1,4 @@
-module Keycloak
+module KeycloakApiRails
   class PublicKeyCachedResolver
     attr_reader :cached_public_key_retrieved_at
 

--- a/lib/keycloak-api-rails/public_key_resolver.rb
+++ b/lib/keycloak-api-rails/public_key_resolver.rb
@@ -1,4 +1,4 @@
-module Keycloak
+module KeycloakApiRails
   class PublicKeyResolver
     def initialize(http_client, realm_id)
       @realm_id    = realm_id

--- a/lib/keycloak-api-rails/railtie.rb
+++ b/lib/keycloak-api-rails/railtie.rb
@@ -1,9 +1,9 @@
-module Keycloak
+module KeycloakApiRails
   class Railtie < Rails::Railtie
     railtie_name :keycloak_api_rails
 
     initializer("keycloak.insert_middleware") do |app|
-      app.config.middleware.use(Keycloak::Middleware)
+      app.config.middleware.use(KeycloakApiRails::Middleware)
     end
   end
 end

--- a/lib/keycloak-api-rails/service.rb
+++ b/lib/keycloak-api-rails/service.rb
@@ -1,12 +1,12 @@
-module Keycloak
+module KeycloakApiRails
   class Service
     
     def initialize(key_resolver)
       @key_resolver                          = key_resolver
-      @skip_paths                            = Keycloak.config.skip_paths
-      @opt_in                                = Keycloak.config.opt_in
-      @logger                                = Keycloak.config.logger
-      @token_expiration_tolerance_in_seconds = Keycloak.config.token_expiration_tolerance_in_seconds
+      @skip_paths                            = KeycloakApiRails.config.skip_paths
+      @opt_in                                = KeycloakApiRails.config.opt_in
+      @logger                                = KeycloakApiRails.config.logger
+      @token_expiration_tolerance_in_seconds = KeycloakApiRails.config.token_expiration_tolerance_in_seconds
     end
 
     def decode_and_verify(token)

--- a/lib/keycloak-api-rails/version.rb
+++ b/lib/keycloak-api-rails/version.rb
@@ -1,3 +1,3 @@
-module Keycloak
+module KeycloakApiRails
   VERSION = "0.12.4"
 end

--- a/spec/keycloak-api-rails/authentication_spec.rb
+++ b/spec/keycloak-api-rails/authentication_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
-describe Keycloak::Authentication do
+describe KeycloakApiRails::Authentication do
   class ExampleController < ActionController::Base
-    include Keycloak::Authentication
+    include KeycloakApiRails::Authentication
     # Mark protected methods public so they may be called in tests
-    public(*Keycloak::Authentication.protected_instance_methods)
+    public(*KeycloakApiRails::Authentication.protected_instance_methods)
   end
 
   let(:controller) { ExampleController.new }
@@ -24,7 +24,7 @@ describe Keycloak::Authentication do
     end
 
     it "it authenticates with request header" do
-      expect_any_instance_of(Keycloak::Service).to receive(:decode_and_verify).with(token).and_return("A User")
+      expect_any_instance_of(KeycloakApiRails::Service).to receive(:decode_and_verify).with(token).and_return("A User")
       expect(controller).to receive(:authentication_succeeded)
       controller.keycloak_authenticate
     end

--- a/spec/keycloak-api-rails/helper_spec.rb
+++ b/spec/keycloak-api-rails/helper_spec.rb
@@ -1,11 +1,11 @@
-RSpec.describe Keycloak::Helper do
+RSpec.describe KeycloakApiRails::Helper do
   describe "#create_url_with_token" do
 
     let(:uri)   { "http://www.an-url.io" }
     let(:token) { "aToken" }
 
     before(:each) do
-      @url_with_token = Keycloak::Helper.create_url_with_token(uri, token)
+      @url_with_token = KeycloakApiRails::Helper.create_url_with_token(uri, token)
     end
 
     context "when the uri has no query string yet" do

--- a/spec/keycloak-api-rails/public_key_cached_resolver_spec.rb
+++ b/spec/keycloak-api-rails/public_key_cached_resolver_spec.rb
@@ -1,12 +1,12 @@
-RSpec.describe Keycloak::Service do
+RSpec.describe KeycloakApiRails::Service do
 
   let(:public_key_cache_ttl)  { 86400 }
   let(:server_url)            { "whatever:8080" }
   let(:realm_id)              { "pouet" }
-  let!(:resolver)             { Keycloak::PublicKeyCachedResolver.new(server_url, realm_id, public_key_cache_ttl) }
+  let!(:resolver)             { KeycloakApiRails::PublicKeyCachedResolver.new(server_url, realm_id, public_key_cache_ttl) }
 
   before(:each) do
-    resolver.instance_variable_set(:@resolver, Keycloak::PublicKeyResolverStub.new)
+    resolver.instance_variable_set(:@resolver, KeycloakApiRails::PublicKeyResolverStub.new)
     now = Time.local(2018, 1, 9, 12, 0, 0)
     Timecop.freeze(now)
   end

--- a/spec/keycloak-api-rails/service_spec.rb
+++ b/spec/keycloak-api-rails/service_spec.rb
@@ -1,9 +1,9 @@
-RSpec.describe Keycloak::Service do
+RSpec.describe KeycloakApiRails::Service do
 
   let!(:private_key)  { OpenSSL::PKey::RSA.generate(2048) }
   let!(:public_key)   { private_key.public_key }
-  let!(:key_resolver)  { Keycloak::PublicKeyCachedResolverStub.new(public_key) }
-  let!(:service)       { Keycloak::Service.new(key_resolver) }
+  let!(:key_resolver)  { KeycloakApiRails::PublicKeyCachedResolverStub.new(public_key) }
+  let!(:service)       { KeycloakApiRails::Service.new(key_resolver) }
   
   before(:each) do
     now = Time.local(2018, 1, 9, 12, 0, 0)
@@ -17,7 +17,7 @@ RSpec.describe Keycloak::Service do
   describe "#decode_and_verify" do
     def create_token(private_key, expiration_date, algorithm)
       claim = {
-        iss: "Keycloak",
+        iss: "KeycloakApiRails",
         exp: expiration_date,
         nbf: Time.local(2018, 1, 1, 0, 0, 0)
       }
@@ -111,7 +111,7 @@ RSpec.describe Keycloak::Service do
 
 
     before(:each) do
-      Keycloak.config.skip_paths = {
+      KeycloakApiRails.config.skip_paths = {
         post:   [/^\/skip/],
         get:    [/^\/skip/]
       }
@@ -178,8 +178,8 @@ RSpec.describe Keycloak::Service do
 
     context "when configured as opt_in" do
       before do
-        Keycloak.config.opt_in = true
-        service2 = Keycloak::Service.new(key_resolver)
+        KeycloakApiRails.config.opt_in = true
+        service2 = KeycloakApiRails::Service.new(key_resolver)
         @result = service2.need_middleware_authentication?(method, path, headers)
       end
 

--- a/spec/support/public_key_cached_resolver_stub.rb
+++ b/spec/support/public_key_cached_resolver_stub.rb
@@ -1,4 +1,4 @@
-module Keycloak
+module KeycloakApiRails
   class PublicKeyCachedResolverStub
     def initialize(public_key)
       @public_key = public_key

--- a/spec/support/public_key_resolver_stub.rb
+++ b/spec/support/public_key_resolver_stub.rb
@@ -1,4 +1,4 @@
-module Keycloak
+module KeycloakApiRails
   class PublicKeyResolverStub
     def find_public_keys
       OpenSSL::PKey::RSA.generate(1024).public_key


### PR DESCRIPTION
I use the keycloak and the keycloak-api-rails gem in my project. This caused some very interesting and subtile issues.

Although I'm aware that renaming the module name is breaking existing code, I really think that the new name is better matching the gem and avoids conflicts.
As the changes in exiting code are very easy to fix, I think this is acceptable.


Thanks for you work btw.. I saved me a lot of time! :) 



